### PR TITLE
feat: improve S3 sync script and env handling

### DIFF
--- a/bucket/package.json
+++ b/bucket/package.json
@@ -1,24 +1,22 @@
 {
-  "name": "bucket",
-  "private": true,
-  "version": "1.0.0",
-  "description": "",
-  "scripts": {
-    "upload": "ts-node scripts/upload-to-s3.ts"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "packageManager": "pnpm@10.6.5",
-  "dependencies": {
-    "@aws-sdk/client-s3": "^3.777.0",
-    "dotenv": "^16.4.7",
-    "fs": "0.0.1-security",
-    "path": "^0.12.7"
-  },
-  "devDependencies": {
-    "@types/node": "^22.13.14",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
-  }
+	"name": "bucket",
+	"private": true,
+	"type": "module",
+	"version": "1.0.0",
+	"description": "",
+	"scripts": {
+		"upload": "node --env-file=.env -r ts-node scripts/upload-to-s3.ts"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"packageManager": "pnpm@10.6.5",
+	"dependencies": {
+		"@aws-sdk/client-s3": "^3.777.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.13.14",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.8.2"
+	}
 }

--- a/bucket/scripts/upload-to-s3.ts
+++ b/bucket/scripts/upload-to-s3.ts
@@ -3,96 +3,115 @@
 /* ---------------------------*/
 
 import {
-  S3Client,
-  PutObjectCommand,
-  ListObjectsV2Command,
-  ObjectCannedACL,
+	ListObjectsV2Command,
+	PutObjectCommand,
+	S3Client,
 } from "@aws-sdk/client-s3";
-import fs from "fs";
-import path from "path";
-import dotenv from "dotenv";
-
-/* ---------------------------*/
-/* Load Environment Variables
-/* ---------------------------*/
-
-dotenv.config();
+import fs from "node:fs";
+import path from "node:path";
 
 /* ---------------------------*/
 /* AWS Configuration
 /* ---------------------------*/
 
-const BUCKET_NAME = process.env.AWS_S3_BUCKET as string;
-const REGION = process.env.AWS_REGION as string;
-const LOCAL_FOLDER = "./icons";
-const S3_PREFIX = "blockicon";
+const {
+	AWS_S3_BUCKET: BUCKET_NAME,
+	AWS_REGION: REGION,
+	AWS_ACCESS_KEY_ID: ACCESS_KEY_ID,
+	AWS_SECRET_ACCESS_KEY: SECRET_ACCESS_KEY,
+} = process.env;
+
+if (!BUCKET_NAME || !REGION || !ACCESS_KEY_ID || !SECRET_ACCESS_KEY) {
+	throw new Error(
+		"Missing required AWS configuration in environment variables.",
+	);
+}
+
+const LOCAL_FOLDER = path.resolve("./icons");
+const S3_PREFIX = "blockicon/";
 
 const s3 = new S3Client({
-  region: REGION,
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID as string,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY as string,
-  },
+	region: REGION,
+	credentials: {
+		accessKeyId: ACCESS_KEY_ID,
+		secretAccessKey: SECRET_ACCESS_KEY,
+	},
 });
 
 /* ---------------------------*/
 /* Functions
 /* ---------------------------*/
 
-const getExistingFiles = async (): Promise<string[]> => {
-  try {
-    const response = await s3.send(
-      new ListObjectsV2Command({ Bucket: BUCKET_NAME, Prefix: S3_PREFIX }),
-    );
-    return response.Contents?.map((file) => file.Key!) || [];
-  } catch (error) {
-    console.error("Error listing S3 objects:", error);
-    return [];
-  }
+const getExistingKeys = async (
+	prefix?: string | undefined,
+): Promise<(string | undefined)[]> => {
+	try {
+		const response = await s3.send(
+			new ListObjectsV2Command({ Bucket: BUCKET_NAME, Prefix: prefix }),
+		);
+
+		return response.Contents?.map(({ Key }) => Key) || [];
+	} catch (err) {
+		console.error("Error listing objects:", err);
+		return [];
+	}
 };
 
-const uploadFile = async (filePath: string, s3Key: string): Promise<void> => {
-  try {
-    const fileStream = fs.createReadStream(filePath);
-    const uploadParams = {
-      Bucket: BUCKET_NAME,
-      Key: s3Key,
-      Body: fileStream,
-      ContentType: "image/svg+xml",
-    };
+const uploadSvg = async (filePath: string, key: string): Promise<void> => {
+	try {
+		const fileStream = fs.createReadStream(filePath);
+		await s3.send(
+			new PutObjectCommand({
+				Bucket: BUCKET_NAME,
+				Key: key,
+				Body: fileStream,
+				ContentType: "image/svg+xml",
+			}),
+		);
 
-    await s3.send(new PutObjectCommand(uploadParams));
-    console.log(`✅ Sent: ${s3Key}`);
-  } catch (error) {
-    console.error(`❌ Error sending ${s3Key}:`, error);
-  }
+		console.log(`✅ Uploaded: ${key}`);
+	} catch (err) {
+		console.error(`❌ Failed to upload ${key}:`, err);
+	}
 };
 
-const syncFolder = async (): Promise<void> => {
-  const existingFiles = await getExistingFiles();
-  const folders = ["network", "token"];
+const syncFolders = async (subfolders: string[] = []): Promise<void> => {
+	const existingKeys = await getExistingKeys(S3_PREFIX);
 
-  for (const folder of folders) {
-    const folderPath = path.join(LOCAL_FOLDER, folder);
-    const filesToUpload = fs
-      .readdirSync(folderPath)
-      .filter((file) => file.endsWith(".svg"));
+	for (const folder of subfolders) {
+		const dirPath = path.join(LOCAL_FOLDER, folder);
+		let files: string[];
 
-    for (const file of filesToUpload) {
-      const filePath = path.join(folderPath, file);
-      const s3Key = `${S3_PREFIX}/${folder}/${file}`;
+		try {
+			files = await fs.readdirSync(dirPath);
+		} catch (err) {
+			console.warn(`Skipping missing folder: ${dirPath}`);
+			continue;
+		}
 
-      if (!existingFiles.includes(s3Key)) {
-        await uploadFile(filePath, s3Key);
-      } else {
-        console.log(`🔄 Already exists in S3: ${s3Key}`);
-      }
-    }
-  }
+		await Promise.all(
+			files
+				.filter((f) => f.endsWith(".svg"))
+				.map(async (file) => {
+					const key = `${S3_PREFIX}${folder}/${file}`;
+					if (!existingKeys.includes(key)) {
+						await uploadSvg(path.join(dirPath, file), key);
+					} else {
+						console.log(`Already exists: ${key}`);
+					}
+				}),
+		);
+	}
 };
 
 /* ---------------------------*/
 /* Execute Sync
 /* ---------------------------*/
-
-syncFolder();
+(async () => {
+	try {
+		await syncFolders(["network", "token"]);
+		console.log("Sync complete");
+	} catch (err) {
+		console.error("Sync failed:", err);
+	}
+})();


### PR DESCRIPTION
Refactors the upload-to-s3 script for better clarity, robustness, and ES module support.

- Adds `"type": "module"` to enable ES module syntax
- Replaces dotenv with `--env-file` for explicit env config
- Validates required AWS env vars before proceeding
- Refactors functions to improve naming and structure
- Uses `node:` imports for built-in modules for clarity
- Makes sync logic more robust and async with `Promise.all`
- Handles missing folders gracefully and logs warnings

These changes make the sync script safer, easier to maintain, and better aligned with modern Node.js practices.